### PR TITLE
Make Action multi-value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
     repositories {
         jcenter()
     }
+    tasks.withType(JavaCompile) { options.fork = true }
 }
 
 task clean(type: Delete) {

--- a/compiller/src/test/java/AutoReducerGeneratorTest.java
+++ b/compiller/src/test/java/AutoReducerGeneratorTest.java
@@ -35,13 +35,14 @@ public class AutoReducerGeneratorTest {
                 "    switch (action.type) {\n" +
                 "      case \"ACTION_1\":\n" +
                 "        return uppercase(state);\n" +
-                "      default: return state;\n" +
+                "      default:\n" +
+                "        return state;\n" +
                 "    }\n" +
                 "  }\n" +
                 "\n" +
                 "  public static class ActionCreator {\n" +
                 "    public static Action uppercase() {\n" +
-                "      return new Action(\"ACTION_1\", null);\n" +
+                "      return Action.create(\"ACTION_1\");\n" +
                 "    }\n" +
                 "  }\n" +
                 "}");
@@ -80,14 +81,15 @@ public class AutoReducerGeneratorTest {
                 "  public String reduce(String state, Action action) {\n" +
                 "    switch (action.type) {\n" +
                 "      case \"ACTION_1\":\n" +
-                "        return append(state, (int) action.value);\n" +
-                "      default: return state;\n" +
+                "        return append(state, (int) action.getValue(0));\n" +
+                "      default:\n" +
+                "        return state;\n" +
                 "    }\n" +
                 "  }\n" +
                 "\n" +
                 "  public static class ActionCreator {\n" +
                 "    public static Action append(int number) {\n" +
-                "      return new Action(\"ACTION_1\", number);\n" +
+                "      return Action.create(\"ACTION_1\", number);\n" +
                 "    }\n" +
                 "  }\n" +
                 "}");
@@ -125,18 +127,16 @@ public class AutoReducerGeneratorTest {
                 "  @Override\n" +
                 "  public String reduce(String state, Action action) {\n" +
                 "    switch (action.type) {\n" +
-                "      case \"ACTION_1\": {\n" +
-                "        Object[] args = (Object[]) action.value;\n" +
-                "        return append(state, (int) args[0], (String) args[1]);\n" +
-                "      }\n" +
-                "      default: return state;\n" +
+                "      case \"ACTION_1\":\n" +
+                "        return append(state, (int) action.getValue(0), (String) action.getValue(1));\n" +
+                "      default:\n" +
+                "        return state;\n" +
                 "    }\n" +
                 "  }\n" +
                 "\n" +
                 "  public static class ActionCreator {\n" +
                 "    public static Action append(int number, String suffix) {\n" +
-                "      Object[] args = new Object[]{number, suffix};\n" +
-                "      return new Action(\"ACTION_1\", args);\n" +
+                "      return Action.create(\"ACTION_1\", number, suffix);\n" +
                 "    }\n" +
                 "  }\n" +
                 "}");

--- a/example/src/main/java/com/yheriatovych/reductor/example/reducers/utils/SetStateReducer.java
+++ b/example/src/main/java/com/yheriatovych/reductor/example/reducers/utils/SetStateReducer.java
@@ -17,13 +17,13 @@ public class SetStateReducer<T> implements Reducer<T> {
     }
 
     public static <T> Action setStateAction(T value) {
-        return new Action(SET_GLOBAL_STATE, value);
+        return Action.create(SET_GLOBAL_STATE, value);
     }
 
     @Override
     public T reduce(T state, Action action) {
         if (action.type.equals(SET_GLOBAL_STATE)) {
-            return (T) action.value;
+            return (T) action.values;
         }
         return source.reduce(state, action);
     }

--- a/example/src/main/java/com/yheriatovych/reductor/example/reducers/utils/UndoableReducer.java
+++ b/example/src/main/java/com/yheriatovych/reductor/example/reducers/utils/UndoableReducer.java
@@ -13,7 +13,7 @@ public class UndoableReducer<State> implements Reducer<State> {
     private final Reducer<State> sourceReducer;
 
     public static Action pop() {
-        return new Action("POP", null);
+        return Action.create("POP");
     }
 
     private LinkedList<State> stack = new LinkedList<>();

--- a/lib/src/main/java/com/yheriatovych/reductor/Action.java
+++ b/lib/src/main/java/com/yheriatovych/reductor/Action.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public class Action {
     public final String type;
-    public final Object value;
+    public final Object[] values;
 
     /**
      * Create Action object with specified type and value
@@ -15,9 +15,9 @@ public class Action {
      * @param type  String type of action, will be used by {@link Reducer} for dispatch
      * @param value any payload to be included with this value
      */
-    public Action(String type, Object value) {
+    public Action(String type, Object[] values) {
         this.type = type;
-        this.value = value;
+        this.values = values;
     }
 
     /**
@@ -26,7 +26,11 @@ public class Action {
      * @param type String type of action, will be used by {@link Reducer} for dispatch
      */
     public Action(String type) {
-        this(type, null);
+        this(type, new Object[0]);
+    }
+
+    public static Action create(String type, Object... values) {
+        return new Action(type, values);
     }
 
     @Override
@@ -37,26 +41,23 @@ public class Action {
         Action action = (Action) o;
 
         if (type != null ? !type.equals(action.type) : action.type != null) return false;
-        return value != null ? value.equals(action.value) : action.value == null;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        return Arrays.equals(values, action.values);
 
     }
 
     @Override
     public int hashCode() {
         int result = type != null ? type.hashCode() : 0;
-        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(values);
         return result;
     }
 
     @Override
     public String toString() {
-        Object valueStr = (this.value instanceof Object[])
-                ? Arrays.toString((Object[]) this.value)
-                : this.value;
-
         return "Action{" +
                 "type='" + type + '\'' +
-                ", value=" + valueStr +
+                ", values=" + Arrays.toString(values) +
                 '}';
     }
 }

--- a/lib/src/main/java/com/yheriatovych/reductor/Action.java
+++ b/lib/src/main/java/com/yheriatovych/reductor/Action.java
@@ -1,5 +1,7 @@
 package com.yheriatovych.reductor;
 
+import java.util.Arrays;
+
 /**
  * Minimal representation of change to be performed on state
  */
@@ -48,9 +50,13 @@ public class Action {
 
     @Override
     public String toString() {
+        Object valueStr = (this.value instanceof Object[])
+                ? Arrays.toString((Object[]) this.value)
+                : this.value;
+
         return "Action{" +
                 "type='" + type + '\'' +
-                ", value=" + value +
+                ", value=" + valueStr +
                 '}';
     }
 }

--- a/lib/src/main/java/com/yheriatovych/reductor/Action.java
+++ b/lib/src/main/java/com/yheriatovych/reductor/Action.java
@@ -10,10 +10,10 @@ public class Action {
     public final Object[] values;
 
     /**
-     * Create Action object with specified type and value
+     * Create Action object with specified type and values
      *
-     * @param type  String type of action, will be used by {@link Reducer} for dispatch
-     * @param value any payload to be included with this value
+     * @param type   String type of action, will be used by {@link Reducer} for dispatch
+     * @param values any number of arbitrary objects that can be attached as payload to this action
      */
     public Action(String type, Object[] values) {
         this.type = type;
@@ -21,7 +21,7 @@ public class Action {
     }
 
     /**
-     * Create Action with defined type and null value
+     * Create Action with defined type without any attached payload
      *
      * @param type String type of action, will be used by {@link Reducer} for dispatch
      */
@@ -29,8 +29,24 @@ public class Action {
         this(type, new Object[0]);
     }
 
+    /**
+     * Factory method to create action with defined type and any number of attached values as payload
+     *
+     * @param type   String type of action, will be used by {@link Reducer} for dispatch
+     * @param values any number of arbitrary objects that can be attached as payload to this action
+     * @return created Action
+     */
     public static Action create(String type, Object... values) {
         return new Action(type, values);
+    }
+
+    /**
+     * Returns action value at given position
+     * @param position value position
+     * @return Object value
+     */
+    public Object getValue(int position) {
+        return values[position];
     }
 
     @Override

--- a/lib/src/main/java/com/yheriatovych/reductor/Store.java
+++ b/lib/src/main/java/com/yheriatovych/reductor/Store.java
@@ -29,7 +29,7 @@ public class Store<State> {
             nextDispatcher = action -> middleware.dispatch(Store.this, action, finalNextDispatcher);
         }
         this.dispatcher = nextDispatcher;
-        dispatchAction(new Action(INIT_ACTION));
+        dispatchAction(Action.create(INIT_ACTION));
     }
 
     private void dispatchAction(final Object actionObject) {

--- a/lib/src/main/java/com/yheriatovych/reductor/annotations/AutoReducer.java
+++ b/lib/src/main/java/com/yheriatovych/reductor/annotations/AutoReducer.java
@@ -46,7 +46,7 @@ public @interface AutoReducer {
      * <li> Return 'next' state
      * <li> Take 'current' state as first argument
      * <li> can have additional arguments as action values
-     * (they will be bundled an passed in {@link com.yheriatovych.reductor.Action#value} automatically)
+     * (they will be bundled an passed in {@link com.yheriatovych.reductor.Action#values} automatically)
      * </ul>
      */
     @Target(ElementType.METHOD)

--- a/lib/src/test/java/com/yheriatovych/reductor/ActionTest.java
+++ b/lib/src/test/java/com/yheriatovych/reductor/ActionTest.java
@@ -1,0 +1,27 @@
+package com.yheriatovych.reductor;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ActionTest {
+
+    @Test
+    public void testActionToStringObject() {
+        Action action = new Action("TEST", 5);
+        assertEquals("Action{type='TEST', value=5}", action.toString());
+    }
+
+    @Test
+    public void testActionToStringObjectArray() {
+        Action action = new Action("TEST", new String[]{"foo", "bar"});
+        assertEquals("Action{type='TEST', value=[foo, bar]}", action.toString());
+    }
+
+    @Test
+    public void testActionToStringObjectNull() {
+        Action action = new Action("TEST", null);
+        assertEquals("Action{type='TEST', value=null}", action.toString());
+    }
+
+}

--- a/lib/src/test/java/com/yheriatovych/reductor/ActionTest.java
+++ b/lib/src/test/java/com/yheriatovych/reductor/ActionTest.java
@@ -8,20 +8,20 @@ public class ActionTest {
 
     @Test
     public void testActionToStringObject() {
-        Action action = new Action("TEST", 5);
-        assertEquals("Action{type='TEST', value=5}", action.toString());
+        Action action = Action.create("TEST", 5);
+        assertEquals("Action{type='TEST', values=[5]}", action.toString());
     }
 
     @Test
     public void testActionToStringObjectArray() {
-        Action action = new Action("TEST", new String[]{"foo", "bar"});
-        assertEquals("Action{type='TEST', value=[foo, bar]}", action.toString());
+        Action action = Action.create("TEST", "foo", "bar");
+        assertEquals("Action{type='TEST', values=[foo, bar]}", action.toString());
     }
 
     @Test
     public void testActionToStringObjectNull() {
-        Action action = new Action("TEST", null);
-        assertEquals("Action{type='TEST', value=null}", action.toString());
+        Action action = Action.create("TEST");
+        assertEquals("Action{type='TEST', values=[]}", action.toString());
     }
 
 }


### PR DESCRIPTION
Currently, Action holds `Object value` as payload.
Most of the time (with `AutoReducer`) `Object[]` is stored there.

 This PR makes Action multi-valued by default, so it's easier to have consistent `hashCode()` and `equals()` methods.