### PR TITLE
Making Epic.run return an Observable<Action>

### DIFF
--- a/reductor-observable/src/main/java/com/yheriatovych/reductor/observable/Epic.java
+++ b/reductor-observable/src/main/java/com/yheriatovych/reductor/observable/Epic.java
@@ -28,5 +28,5 @@ public interface Epic<T> {
      * @param store   a Store object that Epic can use to query the state
      * @return an Observable of actions that will be dispatched back to Store
      */
-    Observable<Object> run(Observable<Action> actions, Store<T> store);
+    Observable<Action> run(Observable<Action> actions, Store<T> store);
 }

--- a/reductor-observable/src/test/java/com/yheriatovych/reductor/observable/EpicMiddlewareTest.java
+++ b/reductor-observable/src/test/java/com/yheriatovych/reductor/observable/EpicMiddlewareTest.java
@@ -31,7 +31,7 @@ public class EpicMiddlewareTest {
     }
 
     @Spy TestReducer reducer = new TestReducer();
-    PublishSubject<Object> epicObservable = PublishSubject.create();
+    PublishSubject<Action> epicObservable = PublishSubject.create();
     @Mock Epic<TestState> epic;
     @Captor ArgumentCaptor<Observable<Action>> actionsCaptor;
     Store<TestState> store;


### PR DESCRIPTION
This change makes the interface consistent with the intent of accepting a stream of Actions and returning another stream of Actions.  The type of `Observable<Object>` was preventing me from performing other operations on the returned observable, such as `.subscribeOn(Schedulers.io)` and `.observeOn(AndroidSchedulers.mainThread()`.