### PR TITLE
Update the docs to reflect updates in gradle usage for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies {
 }
 ```
 
-Apt dependency on `reductor-processor` is only necessary 
+the annotationProcessor dependency on `reductor-processor` is only necessary
 if you want to use features as [@CombinedState](#combine-reducers) and [@AutoReducer](#autoreducer)
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.yheriatovych:reductor:x.x.x'
-    apt     'com.yheriatovych:reductor-processor:x.x.x'
+    implementation      'com.yheriatovych:reductor:x.x.x'
+    annotationProcessor 'com.yheriatovych:reductor-processor:x.x.x'
 }
 ```
 


### PR DESCRIPTION
Not sure if this library is still maintained but its super useful to me, so I'd like to help out if possible.

This is just a little documentation update for the README since its been a long time since we needed to use `apt` and `compile` is deprecated in favour of `implementation`